### PR TITLE
Add missing texture parameter values

### DIFF
--- a/src/gl.re
+++ b/src/gl.re
@@ -135,7 +135,12 @@ type textureParameter =
 type textureParameterValue =
   | GL_REPEAT
   | GL_LINEAR
-  | GL_CLAMP_TO_EDGE;
+  | GL_CLAMP_TO_EDGE
+  | GL_NEAREST
+  | GL_NEAREST_MIPMAP_NEAREST
+  | GL_LINEAR_MIPMAP_NEAREST
+  | GL_NEAREST_MIPMAP_LINEAR
+  | GL_LINEAR_MIPMAP_LINEAR;
 
 type format =
   | GL_ALPHA

--- a/src/gl.rei
+++ b/src/gl.rei
@@ -91,7 +91,12 @@ type textureParameter =
 type textureParameterValue =
   | GL_REPEAT
   | GL_LINEAR
-  | GL_CLAMP_TO_EDGE;
+  | GL_CLAMP_TO_EDGE
+  | GL_NEAREST
+  | GL_NEAREST_MIPMAP_NEAREST
+  | GL_LINEAR_MIPMAP_NEAREST
+  | GL_NEAREST_MIPMAP_LINEAR
+  | GL_LINEAR_MIPMAP_LINEAR;
 
 type format =
   | GL_ALPHA

--- a/src/gl_wrapper.cpp
+++ b/src/gl_wrapper.cpp
@@ -126,6 +126,16 @@ GLenum variantToTextureParameterValue(value vVal) {
     return GL_LINEAR;
   case 2:
     return GL_CLAMP_TO_EDGE;
+  case 3:
+    return GL_NEAREST;
+  case 4:
+    return GL_NEAREST_MIPMAP_NEAREST;
+  case 5:
+    return GL_LINEAR_MIPMAP_NEAREST;
+  case 6:
+    return GL_NEAREST_MIPMAP_LINEAR;
+  case 7:
+    return GL_LINEAR_MIPMAP_LINEAR;
   default:
     warn("Unexpected texture parameter value!");
     return 0;


### PR DESCRIPTION
`GL_NEAREST` is particularly important to prevent bilinear filtering on textures, if necessary