### PR TITLE
API: Sdl.Window.setHitTest

### DIFF
--- a/examples/basic.re
+++ b/examples/basic.re
@@ -371,7 +371,7 @@ let run = () => {
     //print_endline ("Clipboard string after: " ++ v);
 
     /* Run the GC so we can catch any GC-related crashes early! */
-    // Gc.full_major();
+    Gc.full_major();
     //glfwPollEvents();
     //glfwWindowShouldClose(primaryWindow);
     false;

--- a/examples/basic.re
+++ b/examples/basic.re
@@ -82,18 +82,30 @@ let run = () => {
 
   Sdl2.Window.show(primaryWindow);
 
-  Sdl2.Window.setHitTest(primaryWindow, Some((w, x, y) => {
-    let size = Sdl2.Window.getSize(w);
-    let id = Sdl2.Window.getId(w);
-    Printf.printf("hit test - window id: %d width: %d height: %d areaX: %d areaY: %d\n", id, size.width, size.height, x, y);
-    if (x < 10) {
-      ResizeLeft
-    } else {
-      Draggable;
-    }
-  }));
+  Sdl2.Window.setHitTest(
+    primaryWindow,
+    Some(
+      (w, x, y) => {
+        let size = Sdl2.Window.getSize(w);
+        let id = Sdl2.Window.getId(w);
+        Printf.printf(
+          "hit test - window id: %d width: %d height: %d areaX: %d areaY: %d\n",
+          id,
+          size.width,
+          size.height,
+          x,
+          y,
+        );
+        if (x < 10) {
+          ResizeLeft;
+        } else {
+          Draggable;
+        };
+      },
+    ),
+  );
   Sdl2.Window.setBordered(primaryWindow, false);
- // Sdl2.Window.setSize(primaryWindow, 800, 600);
+  // Sdl2.Window.setSize(primaryWindow, 800, 600);
   Sdl2.Window.setResizable(primaryWindow, true);
 
   // Start text input, to experiment with IME + events

--- a/examples/basic.re
+++ b/examples/basic.re
@@ -98,8 +98,10 @@ let run = () => {
         );
         if (x < 10) {
           ResizeLeft;
-        } else {
+        } else if (y < 40){
           Draggable;
+        } else {
+          Normal;
         };
       },
     ),

--- a/examples/basic.re
+++ b/examples/basic.re
@@ -98,7 +98,7 @@ let run = () => {
         );
         if (x < 10) {
           ResizeLeft;
-        } else if (y < 40){
+        } else if (y < 40) {
           Draggable;
         } else {
           Normal;

--- a/examples/basic.re
+++ b/examples/basic.re
@@ -70,6 +70,11 @@ let run = () => {
 
   Sdl2.Window.show(primaryWindow);
 
+  Sdl2.Window.setHitTest(primaryWindow, Some((_, _, _) => Normal));
+  Sdl2.Window.setBordered(primaryWindow, false);
+ // Sdl2.Window.setSize(primaryWindow, 800, 600);
+  Sdl2.Window.setResizable(primaryWindow, true);
+
   // Start text input, to experiment with IME + events
   Sdl2.TextInput.setInputRect(25, 50, 100, 25);
   Sdl2.TextInput.start();

--- a/examples/basic.re
+++ b/examples/basic.re
@@ -83,11 +83,15 @@ let run = () => {
   Sdl2.Window.show(primaryWindow);
 
   Sdl2.Window.setHitTest(primaryWindow, Some((w, x, y) => {
-    let size = Sld2.Window.getSize(w);
+    let size = Sdl2.Window.getSize(w);
     let id = Sdl2.Window.getId(w);
     Printf.printf("hit test - window id: %d width: %d height: %d areaX: %d areaY: %d\n", id, size.width, size.height, x, y);
-    Draggable;
-  });
+    if (x < 10) {
+      ResizeLeft
+    } else {
+      Draggable;
+    }
+  }));
   Sdl2.Window.setBordered(primaryWindow, false);
  // Sdl2.Window.setSize(primaryWindow, 800, 600);
   Sdl2.Window.setResizable(primaryWindow, true);

--- a/examples/basic.re
+++ b/examples/basic.re
@@ -298,7 +298,7 @@ let run = () => {
 
   //let frame = ref(0);
   Sdl2.renderLoop(() => {
-    switch (Sdl2.Event.waitTimeout(1000)) {
+    switch (Sdl2.Event.poll()) {
     | None => ()
     | Some(evt) =>
       print_endline(Sdl2.Event.show(evt));

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "SDL2 bindings for OCaml",
   "license": "MIT",
   "scripts": {
-    "format": "esy dune build @fmt --auto-promote"
+    "format": "esy dune build @fmt --auto-promote",
+    "run": "esy x test_sdl2"
   },
   "esy": {
     "build": [

--- a/src/sdl2.re
+++ b/src/sdl2.re
@@ -69,11 +69,11 @@ module Window = {
   | ResizeTopLeft
   | ResizeTop
   | ResizeTopRight
-  | Right
-  | BottomRight
-  | Bottom
-  | BottomLeft
-  | Left;
+  | ResizeRight
+  | ResizeBottomRight
+  | ResizeBottom
+  | ResizeBottomLeft
+  | ResizeLeft;
 
   type hitTestCallback = (t, int, int) => hitTestResult;
 
@@ -104,7 +104,7 @@ module Window = {
 
   let _hitTest = (win: t, x: int, y: int) => {
     let id = getId(win);
-    switch (Hashtbl.find_opt(windowId)) {
+    switch (Hashtbl.find_opt(_idToHitTest, id)) {
     | Some(v) => v(win, x, y)
     | None => Normal
     }

--- a/src/sdl2.re
+++ b/src/sdl2.re
@@ -62,6 +62,12 @@ module Display = {
 
 module Window = {
   type t;
+
+  type hitTestResult =
+  | Normal;
+
+  type hitTestCallback = (t, int, int) => hitTestResult;
+
   external create: (int, int, string) => t = "resdl_SDL_CreateWindow";
   external getId: t => int = "resdl_SDL_GetWindowId";
   external getSize: t => Size.t = "resdl_SDL_GetWindowSize";
@@ -72,6 +78,20 @@ module Window = {
   external setResizable: (t, bool) => unit = "resdl_SDL_SetWindowResizable";
   external setSize: (t, int, int) => unit = "resdl_SDL_SetWindowSize";
   external setTitle: (t, string) => unit = "resdl_SDL_SetWindowTitle";
+
+  external _enableHitTest: (t) => unit = "resdl_SDL_EnableHitTest";
+  external _disableHitTest: (t) => unit = "resdl_SDL_EnableHitTest";
+
+  let _idToHitTest: Hashtbl.t(int, hitTestCallback) = Hashtbl.create(16);
+
+  let setHitTest = (win: t, cb: option(hitTestCallback)) => {
+    switch (cb) {
+    | None => _disableHitTest(win);
+    | Some(v) => 
+      _enableHitTest(win);
+      Hashtbl.add(_idToHitTest, getId(win), v);
+    }
+  };
 
   external hide: t => unit = "resdl_SDL_HideWindow";
   external raise: t => unit = "resdl_SDL_RaiseWindow";

--- a/src/sdl2.re
+++ b/src/sdl2.re
@@ -64,16 +64,16 @@ module Window = {
   type t;
 
   type hitTestResult =
-  | Normal
-  | Draggable
-  | ResizeTopLeft
-  | ResizeTop
-  | ResizeTopRight
-  | ResizeRight
-  | ResizeBottomRight
-  | ResizeBottom
-  | ResizeBottomLeft
-  | ResizeLeft;
+    | Normal
+    | Draggable
+    | ResizeTopLeft
+    | ResizeTop
+    | ResizeTopRight
+    | ResizeRight
+    | ResizeBottomRight
+    | ResizeBottom
+    | ResizeBottomLeft
+    | ResizeLeft;
 
   type hitTestCallback = (t, int, int) => hitTestResult;
 
@@ -88,18 +88,18 @@ module Window = {
   external setSize: (t, int, int) => unit = "resdl_SDL_SetWindowSize";
   external setTitle: (t, string) => unit = "resdl_SDL_SetWindowTitle";
 
-  external _enableHitTest: (t) => unit = "resdl_SDL_EnableHitTest";
-  external _disableHitTest: (t) => unit = "resdl_SDL_EnableHitTest";
+  external _enableHitTest: t => unit = "resdl_SDL_EnableHitTest";
+  external _disableHitTest: t => unit = "resdl_SDL_EnableHitTest";
 
   let _idToHitTest: Hashtbl.t(int, hitTestCallback) = Hashtbl.create(16);
 
   let setHitTest = (win: t, cb: option(hitTestCallback)) => {
     switch (cb) {
-    | None => _disableHitTest(win);
-    | Some(v) => 
+    | None => _disableHitTest(win)
+    | Some(v) =>
       _enableHitTest(win);
       Hashtbl.add(_idToHitTest, getId(win), v);
-    }
+    };
   };
 
   let _hitTest = (win: t, x: int, y: int) => {
@@ -107,7 +107,7 @@ module Window = {
     switch (Hashtbl.find_opt(_idToHitTest, id)) {
     | Some(v) => v(win, x, y)
     | None => Normal
-    }
+    };
   };
 
   Callback.register("__sdl2_caml_hittest__", _hitTest);

--- a/src/sdl2_wrapper.cpp
+++ b/src/sdl2_wrapper.cpp
@@ -27,7 +27,6 @@ static value Val_some(value v) {
   Store_field(some, 0, v);
   CAMLreturn(some);
 }
-
 static value Val_ok(value v) {
   CAMLparam1(v);
   CAMLlocal1(some);
@@ -45,6 +44,27 @@ static value Val_error(value v) {
 }
 
 extern "C" {
+
+SDL_HitTestResult resdl_hit_test(
+  SDL_Window *win,
+  const SDL_Point *area,
+  void *data) {
+    printf("Checking hit test");
+    return SDL_HITTEST_DRAGGABLE;
+  };
+
+CAMLprim value resdl_SDL_EnableHitTest(value vWin) {
+  SDL_Window *win = (SDL_Window *)vWin;
+  SDL_SetWindowHitTest(win, resdl_hit_test, NULL);
+  return Val_unit;
+}
+
+CAMLprim value resdl_SDL_DisableHitTest(value vWin) {
+  SDL_Window *win = (SDL_Window *)vWin;
+  SDL_SetWindowHitTest(win, NULL, NULL);
+  return Val_unit;
+}
+
 CAMLprim value resdl_SDL_SetMainReady() {
   SDL_SetMainReady();
 

--- a/src/sdl2_wrapper.cpp
+++ b/src/sdl2_wrapper.cpp
@@ -65,7 +65,8 @@ SDL_HitTestResult resdl_hit_test(
     if (hitTestCallback == NULL) {
       hitTestCallback = caml_named_value("__sdl2_caml_hittest__");
     }
-    value vRet = caml_callback3(hitTestCallback, win, Val_int(area->x), Val_int(area->y));
+    value vWin = (value)win;
+    value vRet = caml_callback3(*hitTestCallback, vWin, Val_int(area->x), Val_int(area->y));
     SDL_HitTestResult result;
     switch (Int_val(vRet)) {
       case 0:

--- a/src/sdl2_wrapper.cpp
+++ b/src/sdl2_wrapper.cpp
@@ -49,8 +49,17 @@ SDL_HitTestResult resdl_hit_test(
   SDL_Window *win,
   const SDL_Point *area,
   void *data) {
-    printf("Checking hit test");
+    printf("Checking hit test: %d, %d\n", area->x, area->y);
+    if (area->y < 10) {
+    printf("- resize-top\n");
+    return SDL_HITTEST_RESIZE_LEFT;
+    } else if(area->y < 40) {
+    printf("- raggable\n");
     return SDL_HITTEST_DRAGGABLE;
+    } else {
+    printf("- normal\nb");
+    return SDL_HITTEST_NORMAL;
+    }
   };
 
 CAMLprim value resdl_SDL_EnableHitTest(value vWin) {
@@ -704,10 +713,6 @@ CAMLprim value resdl_SDL_GL_SwapWindow(value w) {
   SDL_Window *win = (SDL_Window *)w;
   SDL_GL_SwapWindow(win);
   return Val_unit;
-}
-
-SDL_HitTestResult hittest(SDL_Window *win, const SDL_Point *area, void *data) {
-  return SDL_HITTEST_DRAGGABLE;
 }
 
 CAMLprim value resdl_SDL_SetWindowSize(value vWin, value vW, value vH) {


### PR DESCRIPTION
This API is necessary to allow frameless windows / custom title bars. Without it - we won't be able to drag, move, or resize frameless or titleless windows.