### PR TITLE
Add pan events

### DIFF
--- a/src/sdl2.re
+++ b/src/sdl2.re
@@ -416,8 +416,15 @@ module Event = {
         deltaY,
         isFlipped ? 1 : 0,
       )
-    | Pan =>
-        Printf.sprintf("Pan event")
+    | MousePan({windowID, deltaX, deltaY, containsX, containsY, isFling, isInterrupt, _}) =>
+      Printf.sprintf("Pan event: %d %d %d %d %d %d %d",
+                     windowID,
+                     deltaX,
+                     deltaY,
+                     if(containsX) 1 else 0,
+                     if(containsY) 1 else 0,
+                     if(isFling) 1 else 0,
+                     if(isInterrupt) 1 else 0)
     | MouseButtonUp({windowID, button, _}) =>
       Printf.sprintf(
         "MouseButtonUp windowId: %d button: %s",

--- a/src/sdl2.re
+++ b/src/sdl2.re
@@ -242,6 +242,18 @@ module Keycode = {
   let left = 1073741904;
 };
 
+module WheelType = {
+    type t =
+      | Last
+      | Undefined
+      | Touchscreen
+      | Touchpad
+      | Wheel
+      | WheelPrecise
+      | OtherNonKinetic
+      | OtherKinetic;
+}
+
 module Keymod = {
   type t = int;
 
@@ -307,6 +319,17 @@ module Event = {
     deltaY: int,
     isFlipped: bool,
   };
+
+  type mousePan = {
+    windowID: int,
+    deltaX: int,
+    deltaY: int,
+    containsX: bool,
+    containsY: bool,
+    isFling: bool,
+    isInterrupt: bool,
+    source: WheelType.t,
+  }
 
   type mouseButtonEvent = {
     windowID: int,
@@ -376,6 +399,7 @@ module Event = {
     | WindowClosed(windowEvent)
     | WindowTakeFocus(windowEvent)
     | WindowHitTest(windowEvent)
+    | MousePan(mousePan)
     // An event that hasn't been implemented yet
     | Unknown;
 
@@ -392,6 +416,8 @@ module Event = {
         deltaY,
         isFlipped ? 1 : 0,
       )
+    | Pan =>
+        Printf.sprintf("Pan event")
     | MouseButtonUp({windowID, button, _}) =>
       Printf.sprintf(
         "MouseButtonUp windowId: %d button: %s",

--- a/src/sdl2_wrapper.cpp
+++ b/src/sdl2_wrapper.cpp
@@ -550,6 +550,20 @@ CAMLprim value Val_SDL_Event(SDL_Event *event) {
     case SDL_WINDOWEVENT_HIT_TEST:
       v = Val_SDL_WindowEvent(23, event->window.windowID);
       break;
+    case SDL_PANEVENT:
+      v = caml_alloc(1, 24);
+
+      vInner = caml_alloc(8, 0);
+      Store_field(vInner, 0, Val_int(event->window.windowID));
+      Store_field(vInner, 1, Val_int(event->pan.x));
+      Store_field(vInner, 2, Val_int(event->pan.y));
+      Store_field(vInner, 3, Val_bool(event->pan.contains_x));
+      Store_field(vInner, 4, Val_bool(event->pan.contains_y));
+      Store_field(vInner, 5, Val_bool(event->pan.fling));
+      Store_field(vInner, 6, Val_bool(event->pan.interrupt));
+      // verify this is the correct way of representing a ref to some WheelType.t
+      Store_field(vInner, 7, Val_int(event->pan.source_type));
+      break;
     default:
       v = Val_int(1);
     };

--- a/src/sdl2_wrapper.cpp
+++ b/src/sdl2_wrapper.cpp
@@ -401,8 +401,6 @@ CAMLprim value Val_SDL_Event(SDL_Event *event) {
 
   int tag, mouseButton;
 
-  printf("event type is %d while pan event type is %d and mousewheel is %d\n", event->type, SDL_PANEVENT, SDL_MOUSEWHEEL);
-
   switch (event->type) {
   case SDL_QUIT:
     v = Val_int(0);
@@ -500,7 +498,6 @@ CAMLprim value Val_SDL_Event(SDL_Event *event) {
     Store_field(v, 0, vInner);
     break;
   case SDL_PANEVENT:
-    printf("dispatches pan event from wrapper\n");
     v = caml_alloc(1, 24);
 
     vInner = caml_alloc(8, 0);
@@ -515,7 +512,6 @@ CAMLprim value Val_SDL_Event(SDL_Event *event) {
     Store_field(vInner, 7, Val_int(event->pan.source_type));
 
     Store_field(v, 0, vInner);
-    printf("stored fields\n");
     break;
   case SDL_WINDOWEVENT:
     switch (event->window.event) {

--- a/src/sdl2_wrapper.cpp
+++ b/src/sdl2_wrapper.cpp
@@ -567,7 +567,7 @@ CAMLprim value Val_SDL_Event(SDL_Event *event) {
       v = Val_SDL_WindowEvent(23, event->window.windowID);
       break;
     default:
-      printf("Unknown event in sdl2_wrapper, event enum code was %d\n", event->type);
+      fprintf(stderr, "Unknown event in sdl2_wrapper, event enum code was %d\n", event->type);
       v = Val_int(1);
     };
 

--- a/src/sdl2_wrapper.cpp
+++ b/src/sdl2_wrapper.cpp
@@ -608,7 +608,6 @@ CAMLprim value Val_SDL_Event(SDL_Event *event) {
       v = Val_SDL_WindowEvent(23, event->window.windowID);
       break;
     default:
-      fprintf(stderr, "Unknown event in sdl2_wrapper, event enum code was %d\n", event->type);
       v = Val_int(1);
     };
 

--- a/src/sdl2_wrapper.cpp
+++ b/src/sdl2_wrapper.cpp
@@ -401,6 +401,8 @@ CAMLprim value Val_SDL_Event(SDL_Event *event) {
 
   int tag, mouseButton;
 
+  printf("event type is %d while pan event type is %d and mousewheel is %d\n", event->type, SDL_PANEVENT, SDL_MOUSEWHEEL);
+
   switch (event->type) {
   case SDL_QUIT:
     v = Val_int(0);
@@ -497,6 +499,24 @@ CAMLprim value Val_SDL_Event(SDL_Event *event) {
 
     Store_field(v, 0, vInner);
     break;
+  case SDL_PANEVENT:
+    printf("dispatches pan event from wrapper\n");
+    v = caml_alloc(1, 24);
+
+    vInner = caml_alloc(8, 0);
+    Store_field(vInner, 0, Val_int(event->window.windowID));
+    Store_field(vInner, 1, Val_int(event->pan.x));
+    Store_field(vInner, 2, Val_int(event->pan.y));
+    Store_field(vInner, 3, Val_bool(event->pan.contains_x));
+    Store_field(vInner, 4, Val_bool(event->pan.contains_y));
+    Store_field(vInner, 5, Val_bool(event->pan.fling));
+    Store_field(vInner, 6, Val_bool(event->pan.interrupt));
+    // verify this is the correct way of representing a ref to some WheelType.t
+    Store_field(vInner, 7, Val_int(event->pan.source_type));
+
+    Store_field(v, 0, vInner);
+    printf("stored fields\n");
+    break;
   case SDL_WINDOWEVENT:
     switch (event->window.event) {
     case SDL_WINDOWEVENT_SHOWN:
@@ -550,21 +570,8 @@ CAMLprim value Val_SDL_Event(SDL_Event *event) {
     case SDL_WINDOWEVENT_HIT_TEST:
       v = Val_SDL_WindowEvent(23, event->window.windowID);
       break;
-    case SDL_PANEVENT:
-      v = caml_alloc(1, 24);
-
-      vInner = caml_alloc(8, 0);
-      Store_field(vInner, 0, Val_int(event->window.windowID));
-      Store_field(vInner, 1, Val_int(event->pan.x));
-      Store_field(vInner, 2, Val_int(event->pan.y));
-      Store_field(vInner, 3, Val_bool(event->pan.contains_x));
-      Store_field(vInner, 4, Val_bool(event->pan.contains_y));
-      Store_field(vInner, 5, Val_bool(event->pan.fling));
-      Store_field(vInner, 6, Val_bool(event->pan.interrupt));
-      // verify this is the correct way of representing a ref to some WheelType.t
-      Store_field(vInner, 7, Val_int(event->pan.source_type));
-      break;
     default:
+      printf("Unknown event in sdl2_wrapper, event enum code was %d\n", event->type);
       v = Val_int(1);
     };
 


### PR DESCRIPTION
WIP: plumbs support for smooth scrolling

Adds a new "MousePan" event type that matches up with https://github.com/revery-ui/esy-sdl2/pull/6

Needs to be integrated with Revery proper before it will work