### PR TITLE
Add functions to customize Mac (Cocoa) titlebar

### DIFF
--- a/config/discover.ml
+++ b/config/discover.ml
@@ -63,6 +63,7 @@ let cxx_flags =
     match get_os with
     | Linux -> c_flags @ ["-std=c++11"]
     | Windows -> c_flags @ ["-fno-exceptions"; "-fno-rtti"; "-lstdc++"]
+    | Mac -> c_flags @ ["-x"; "objective-c++"]
     | _ -> c_flags
 ;;
 

--- a/examples/basic.re
+++ b/examples/basic.re
@@ -80,6 +80,9 @@ let run = () => {
   Sdl2.Window.setSize(primaryWindow, 800, 600);
   Sdl2.Window.center(primaryWindow);
 
+  Sdl2.Window.setMacBackgroundColor(primaryWindow, 0.0, 0.0, 0.0, 1.);
+  Sdl2.Window.setMacTitlebarTransparent(primaryWindow);
+
   Sdl2.Window.show(primaryWindow);
 
   /*Sdl2.Window.setHitTest(
@@ -110,6 +113,8 @@ let run = () => {
   // Sdl2.Window.setSize(primaryWindow, 800, 600);
   Sdl2.Window.setResizable(primaryWindow, true);
   Sdl2.Window.setMinimumSize(primaryWindow, 200, 100);
+
+  print_endline("setting transparent");
 
   // Start text input, to experiment with IME + events
   Sdl2.TextInput.setInputRect(25, 50, 100, 25);

--- a/examples/basic.re
+++ b/examples/basic.re
@@ -114,8 +114,6 @@ let run = () => {
   Sdl2.Window.setResizable(primaryWindow, true);
   Sdl2.Window.setMinimumSize(primaryWindow, 200, 100);
 
-  print_endline("setting transparent");
-
   // Start text input, to experiment with IME + events
   Sdl2.TextInput.setInputRect(25, 50, 100, 25);
   Sdl2.TextInput.start();

--- a/src/sdl2.re
+++ b/src/sdl2.re
@@ -141,6 +141,10 @@ module Window = {
 
   type nativeWindow;
   external getNativeWindow: t => nativeWindow = "resdl_SDL_GetNativeWindow";
+
+  // MacOS-Only
+  external setMacTitlebarTransparent: t => unit = "resdl_SDL_SetMacTitlebarTransparent";
+  external setMacBackgroundColor: (t, float, float, float, float) => unit = "resdl_SDL_SetMacBackgroundColor";
 };
 
 module OldGl = Gl;

--- a/src/sdl2_wrapper.cpp
+++ b/src/sdl2_wrapper.cpp
@@ -19,6 +19,11 @@
 #include <SDL2/SDL.h>
 #include <SDL2/SDL_syswm.h>
 
+#ifdef __APPLE__
+#import <Cocoa/Cocoa.h>
+#endif
+
+
 #define Val_none Val_int(0)
 static value Val_some(value v) {
   CAMLparam1(v);
@@ -196,6 +201,41 @@ CAMLprim value resdl_SDL_GetNativeWindow(value vWin) {
 
   CAMLreturn((value)pNativeWindow);
 };
+
+CAMLprim value resdl_SDL_SetMacTitlebarTransparent(value vWin) {
+  CAMLparam1(vWin);
+
+  #ifdef __APPLE__
+  SDL_Window *win = (SDL_Window *)vWin;
+  SDL_SysWMinfo wmInfo;
+  SDL_VERSION(&wmInfo.version);
+  SDL_GetWindowWMInfo(win, &wmInfo);
+  NSWindow *nWindow = wmInfo.info.cocoa.window;
+  [nWindow setTitlebarAppearsTransparent:YES];
+  #endif
+
+  CAMLreturn(Val_unit);
+}
+
+CAMLprim value resdl_SDL_SetMacBackgroundColor(value vWin, value r, value g, value b, value a) {
+  CAMLparam5(vWin, r, g, b, a);
+
+  #ifdef __APPLE__
+  SDL_Window *win = (SDL_Window *)vWin;
+  SDL_SysWMinfo wmInfo;
+  SDL_VERSION(&wmInfo.version);
+  SDL_GetWindowWMInfo(win, &wmInfo);
+  double red = Double_val(r);
+  double green = Double_val(g);
+  double blue = Double_val(b);
+  double alpha = Double_val(a);
+  NSWindow *nWindow = wmInfo.info.cocoa.window;
+  NSColor *rgb = [NSColor colorWithDeviceRed:red green:green blue:blue alpha:alpha];
+  [nWindow setBackgroundColor:rgb];
+  #endif
+
+  CAMLreturn(Val_unit);
+}
 
 CAMLprim value resdl_SDL_SetWin32ProcessDPIAware(value vWin) {
   CAMLparam1(vWin);

--- a/src/sdl2_wrapper.cpp
+++ b/src/sdl2_wrapper.cpp
@@ -211,6 +211,7 @@ CAMLprim value resdl_SDL_SetMacTitlebarTransparent(value vWin) {
   SDL_VERSION(&wmInfo.version);
   SDL_GetWindowWMInfo(win, &wmInfo);
   NSWindow *nWindow = wmInfo.info.cocoa.window;
+  [nWindow setStyleMask: [nWindow styleMask] | NSWindowStyleMaskFullSizeContentView];
   [nWindow setTitlebarAppearsTransparent:YES];
   #endif
 


### PR DESCRIPTION
Binds to:
- `NSWindow setTitlebarAppearsTransparent`
- `NSWindow setBackgroundColor`
  - this sets the background color of the window, which changes the titlebar