### PR TITLE
Bind to SetWindowOpacity

### DIFF
--- a/examples/basic.re
+++ b/examples/basic.re
@@ -80,6 +80,8 @@ let run = () => {
   Sdl2.Window.setSize(primaryWindow, 800, 600);
   Sdl2.Window.center(primaryWindow);
 
+  Sdl2.Window.setTransparency(primaryWindow, 0.8);
+
   Sdl2.Window.setMacBackgroundColor(primaryWindow, 0.0, 0.0, 0.0, 1.);
   Sdl2.Window.setMacTitlebarTransparent(primaryWindow);
 

--- a/src/sdl2.re
+++ b/src/sdl2.re
@@ -88,6 +88,8 @@ module Window = {
   external getSize: t => Size.t = "resdl_SDL_GetWindowSize";
   external setBordered: (t, bool) => unit = "resdl_SDL_SetWindowBordered";
   external setIcon: (t, Surface.t) => unit = "resdl_SDL_SetWindowIcon";
+  external setTransparency: (t, float) => unit =
+    "resdl_SDL_SetWindowTransparency";
   external setPosition: (t, int, int) => unit = "resdl_SDL_SetWindowPosition";
   external center: t => unit = "resdl_SDL_WindowCenter";
   external setResizable: (t, bool) => unit = "resdl_SDL_SetWindowResizable";
@@ -143,8 +145,10 @@ module Window = {
   external getNativeWindow: t => nativeWindow = "resdl_SDL_GetNativeWindow";
 
   // MacOS-Only
-  external setMacTitlebarTransparent: t => unit = "resdl_SDL_SetMacTitlebarTransparent";
-  external setMacBackgroundColor: (t, float, float, float, float) => unit = "resdl_SDL_SetMacBackgroundColor";
+  external setMacTitlebarTransparent: t => unit =
+    "resdl_SDL_SetMacTitlebarTransparent";
+  external setMacBackgroundColor: (t, float, float, float, float) => unit =
+    "resdl_SDL_SetMacBackgroundColor";
 };
 
 module OldGl = Gl;

--- a/src/sdl2_wrapper.cpp
+++ b/src/sdl2_wrapper.cpp
@@ -705,6 +705,22 @@ CAMLprim value resdl_SDL_SetWindowIcon(value vWindow, value vIcon) {
   CAMLreturn(Val_unit);
 };
 
+CAMLprim value resdl_SDL_SetWindowTransparency(value vWindow, value vTransparency) {
+  CAMLparam2(vWindow, vTransparency);
+
+  SDL_Window *win = (SDL_Window *)vWindow;
+  double transparency = Double_val(vTransparency);
+
+  int result;
+  result = SDL_SetWindowOpacity(win, transparency);
+
+  if (result == -1) {
+    printf("WARNING: Setting transparency not supported!");
+  }
+
+  CAMLreturn(Val_unit);
+}
+
 CAMLprim value resdl_SDL_CreateSystemCursor(value vCursor) {
   CAMLparam1(vCursor);
 


### PR DESCRIPTION
This PR binds to SDL's `SDL_SetWindowOpacity` function, which sets window transparency on Windows, macOS, X11, and DirectFB.