### PR TITLE
fix: replace `nth_dim` with direct array access

### DIFF
--- a/src/gl_stubs.js
+++ b/src/gl_stubs.js
@@ -287,8 +287,8 @@ function caml_glReadPixels(x, y, vFormat, vType, vPixels) {
     joo_global_object.console.log("Warning: Your browser most likely doesn't support GL_RGB. Try GL_RGBA if you see an error");
   }
 
-  var width = vPixels.nth_dim(1) / numChannels;
-  var height = vPixels.nth_dim(0);
+  var width = vPixels.dims[1] / numChannels;
+  var height = vPixels.dims[0];
   var pixels = vPixels.data;
   joo_global_object.gl.readPixels(x, y, width, height, format, type, pixels);
 


### PR DESCRIPTION
Missed a second call to `nth_dim`. Should be good to merge as is.