### PR TITLE
Bugfix: Don't crash if glString returns NULL

### DIFF
--- a/src/gl_wrapper.cpp
+++ b/src/gl_wrapper.cpp
@@ -522,11 +522,18 @@ CAMLprim value caml_glTexImage2D_native(value vTextureType, value vLevel,
 
 CAMLprim value caml_glGetString(value vVal) {
   CAMLparam1(vVal);
+  CAMLlocal1(ret);
 
   GLenum str = variantToGlString(vVal);
   const char* sz = (const char *)glGetString(str);
 
-  CAMLreturn(caml_copy_string(sz));
+  if (!sz) {
+    ret = caml_copy_string("Unknown");
+  } else {
+    ret = caml_copy_string(sz); 
+  }
+
+  CAMLreturn(ret);
 };
 
 CAMLprim value caml_glTexImage2D_bytecode(value *argv, int argn) {

--- a/src/sdl2.re
+++ b/src/sdl2.re
@@ -143,8 +143,10 @@ module Window = {
   external getNativeWindow: t => nativeWindow = "resdl_SDL_GetNativeWindow";
 
   // MacOS-Only
-  external setMacTitlebarTransparent: t => unit = "resdl_SDL_SetMacTitlebarTransparent";
-  external setMacBackgroundColor: (t, float, float, float, float) => unit = "resdl_SDL_SetMacBackgroundColor";
+  external setMacTitlebarTransparent: t => unit =
+    "resdl_SDL_SetMacTitlebarTransparent";
+  external setMacBackgroundColor: (t, float, float, float, float) => unit =
+    "resdl_SDL_SetMacBackgroundColor";
 };
 
 module OldGl = Gl;


### PR DESCRIPTION
Related to https://github.com/onivim/oni2/issues/976

It's not clear why, but in the particular MacOS config in https://github.com/onivim/oni2/issues/976, we're getting a `NULL` returned for `glGetString`. This may be indicative of other OpenGL issues, but it seems at least a window and context were created at that point.

This handles the case where we get a null and used the hardcoded string `Unknown`.