### PR TITLE
[FIX] free variables in primitive code "caml_glGetString".

### DIFF
--- a/src/gl_stubs.js
+++ b/src/gl_stubs.js
@@ -22,6 +22,7 @@ function caml_glClearDepth(d) {
 }
 
 // Provides: caml_glGetString
+// Requires: caml_js_to_string
 function caml_glGetString() {
     return caml_js_to_string("Not implemented");
 }


### PR DESCRIPTION
When building a build with all flag turned enable in revery (aka `esy build dune build`)
```
warning: free variables in primitive code "caml_glGetString" (X:/usr/root/.esy/3_/i/reason_sdl2-2.10.3011-29248f10/lib\sdl2\gl_stubs.js:23)
vars: caml_js_to_string
code providing caml_glGetString (X:/usr/root/.esy/3_/i/reason_sdl2-2.10.3011-29248f10/lib\sdl2\gl_stubs.js:23) may miss dependencies: caml_js_to_string
```