### PR TITLE
API: Hide title text with setMacTitlebarTransparent(true)

### DIFF
--- a/src/sdl2_wrapper.cpp
+++ b/src/sdl2_wrapper.cpp
@@ -318,6 +318,7 @@ CAMLprim value resdl_SDL_SetMacTitlebarTransparent(value vWin) {
   [nWindow
       setStyleMask:[nWindow styleMask] | NSWindowStyleMaskFullSizeContentView];
   [nWindow setTitlebarAppearsTransparent:YES];
+  nWindow.titleVisibility = NSWindowTitleHidden;
 #endif
 
   CAMLreturn(Val_unit);


### PR DESCRIPTION
Since we can't control the title text color, I think it makes sense to hide the text along with the titlebar with `setMacTitlebarTransparent`