### PR TITLE
Add getticks

### DIFF
--- a/src/sdl2.re
+++ b/src/sdl2.re
@@ -347,6 +347,7 @@ module Event = {
     isFling: bool,
     isInterrupt: bool,
     source: WheelType.t,
+    timestamp: int,
   };
 
   type mouseButtonEvent = {

--- a/src/sdl2.re
+++ b/src/sdl2.re
@@ -580,6 +580,10 @@ module MessageBox = {
     "resdl_SDL_ShowSimpleMessageBox";
 };
 
+module Timekeeping = {
+    external getTicks: unit => int = "resdl_SDL_GetTicks";
+}
+
 type renderFunction = unit => bool;
 external _javaScriptRenderLoop: renderFunction => unit =
   "resdl__javascript__renderloop";

--- a/src/sdl2_wrapper.cpp
+++ b/src/sdl2_wrapper.cpp
@@ -615,6 +615,7 @@ CAMLprim value Val_SDL_Event(SDL_Event *event) {
     break;
   case SDL_KEYDOWN:
   case SDL_KEYUP:
+    fprintf(stderr, "Got keyup event\n");
     v = caml_alloc(1, event->type == SDL_KEYDOWN ? 4 : 5);
 
     vInner = caml_alloc(5, 0);
@@ -659,6 +660,7 @@ CAMLprim value Val_SDL_Event(SDL_Event *event) {
     Store_field(vInner, 6, Val_bool(event->pan.interrupt));
     // verify this is the correct way of representing a ref to some WheelType.t
     Store_field(vInner, 7, Val_int(event->pan.source_type));
+    Store_field(vInner, 8, Val_int(event->pan.timestamp));
 
     Store_field(v, 0, vInner);
     break;

--- a/src/sdl2_wrapper.cpp
+++ b/src/sdl2_wrapper.cpp
@@ -796,6 +796,12 @@ CAMLprim value resdl_SDL_WaitTimeoutEvent(value vTimeout) {
   CAMLreturn(ret);
 }
 
+CAMLprim value resdl_SDL_GetTicks() {
+    int result = SDL_GetTicks();
+
+    CAMLreturn(Val_int(result));
+}
+
 CAMLprim value resdl_SDL_GetWindowSize(value vWindow) {
   CAMLparam1(vWindow);
   CAMLlocal1(ret);

--- a/src/sdl2_wrapper.cpp
+++ b/src/sdl2_wrapper.cpp
@@ -797,6 +797,8 @@ CAMLprim value resdl_SDL_WaitTimeoutEvent(value vTimeout) {
 }
 
 CAMLprim value resdl_SDL_GetTicks() {
+    CAMLparam0();
+
     int result = SDL_GetTicks();
 
     CAMLreturn(Val_int(result));

--- a/src/sdl2_wrapper.cpp
+++ b/src/sdl2_wrapper.cpp
@@ -615,7 +615,6 @@ CAMLprim value Val_SDL_Event(SDL_Event *event) {
     break;
   case SDL_KEYDOWN:
   case SDL_KEYUP:
-    fprintf(stderr, "Got keyup event\n");
     v = caml_alloc(1, event->type == SDL_KEYDOWN ? 4 : 5);
 
     vInner = caml_alloc(5, 0);


### PR DESCRIPTION
Adds a way of getting the value of the timer used for timestamps in input events. Will allow for proper sampling with libscroll