### PR TITLE
Add getticks

### DIFF
--- a/src/sdl2.re
+++ b/src/sdl2.re
@@ -579,6 +579,10 @@ module MessageBox = {
     "resdl_SDL_ShowSimpleMessageBox";
 };
 
+module Timekeeping = {
+    external getTicks: unit => int = "resdl_SDL_GetTicks";
+}
+
 type renderFunction = unit => bool;
 external _javaScriptRenderLoop: renderFunction => unit =
   "resdl__javascript__renderloop";

--- a/src/sdl2.re
+++ b/src/sdl2.re
@@ -580,8 +580,8 @@ module MessageBox = {
 };
 
 module Timekeeping = {
-    external getTicks: unit => int = "resdl_SDL_GetTicks";
-}
+  external getTicks: unit => int = "resdl_SDL_GetTicks";
+};
 
 type renderFunction = unit => bool;
 external _javaScriptRenderLoop: renderFunction => unit =

--- a/src/sdl2_wrapper.cpp
+++ b/src/sdl2_wrapper.cpp
@@ -796,6 +796,8 @@ CAMLprim value resdl_SDL_WaitTimeoutEvent(value vTimeout) {
 }
 
 CAMLprim value resdl_SDL_GetTicks() {
+    CAMLparam0();
+
     int result = SDL_GetTicks();
 
     CAMLreturn(Val_int(result));

--- a/src/sdl2_wrapper.cpp
+++ b/src/sdl2_wrapper.cpp
@@ -795,6 +795,12 @@ CAMLprim value resdl_SDL_WaitTimeoutEvent(value vTimeout) {
   CAMLreturn(ret);
 }
 
+CAMLprim value resdl_SDL_GetTicks() {
+    int result = SDL_GetTicks();
+
+    CAMLreturn(Val_int(result));
+}
+
 CAMLprim value resdl_SDL_GetWindowSize(value vWindow) {
   CAMLparam1(vWindow);
   CAMLlocal1(ret);


### PR DESCRIPTION
Adds a way of getting the value of the timer used for timestamps in input events. Will allow for proper sampling with libscroll