### PR TITLE
Bugfix: Null check for glGetString

### DIFF
--- a/src/sdl2_wrapper.cpp
+++ b/src/sdl2_wrapper.cpp
@@ -515,7 +515,11 @@ CAMLprim value resdl_SDL_GL_GetString(value vStr) {
     ret = caml_copy_string("Unable to get OpenGL proc address for glGetString");
   } else {
     const char *sz = (const char *)((void *)glGetString(name));
-    ret = caml_copy_string(sz);
+    if (!sz) {
+      ret = caml_copy_string("(null)");
+    } else {
+      ret = caml_copy_string(sz);
+    }
   }
 
   CAMLreturn(ret);


### PR DESCRIPTION
__Issue:__ In cases where `glGetString` returned `NULL`, we would crash

__Defect:__ Although we referenced the `glGetString` function itself is non-null, we were not validating that the string returned by `glGetString` was `NULL`

__Fix:__ Add a null-check, return `"(null)"` if the return value from `glGetString` is null.

Related:
https://github.com/onivim/oni2/issues/1522
https://github.com/onivim/oni2/issues/1185