### PR TITLE
API: Add PixelFormat module / type, hook up to window

### DIFF
--- a/examples/basic.re
+++ b/examples/basic.re
@@ -35,10 +35,18 @@ let run = () => {
 
   Console.log(
     Printf.sprintf(
-      "OpenGL Info - version: %s vendor: %s shading language version: %s\n",
+      "OpenGL Info - version: %s vendor: %s shading language version: %s",
       version,
       vendor,
       shadingLanguageVersion,
+    ),
+  );
+
+  let pixelFormat = Sdl2.Window.getPixelFormat(primaryWindow);
+  Console.log(
+    Printf.sprintf(
+      "Pixel format: %s",
+      pixelFormat |> Sdl2.PixelFormat.toString,
     ),
   );
 

--- a/src/sdl2.re
+++ b/src/sdl2.re
@@ -65,6 +65,12 @@ module Display = {
   external getDesktopMode: t => Mode.t = "resdl_SDL_GetDesktopDisplayMode";
 };
 
+module PixelFormat = {
+  type t;
+
+  external toString: t => string = "resdl_SDL_GetPixelFormatName";
+};
+
 module Log = {
   type category =
     | Application
@@ -132,6 +138,8 @@ module Window = {
   external getId: t => int = "resdl_SDL_GetWindowId";
   external getSize: t => Size.t = "resdl_SDL_GetWindowSize";
   external setBordered: (t, bool) => unit = "resdl_SDL_SetWindowBordered";
+  external getPixelFormat: t => PixelFormat.t =
+    "resdl_SDL_GetWindowPixelFormat";
   external setIcon: (t, Surface.t) => unit = "resdl_SDL_SetWindowIcon";
   external setTransparency: (t, float) => unit =
     "resdl_SDL_SetWindowTransparency";

--- a/src/sdl2_wrapper.cpp
+++ b/src/sdl2_wrapper.cpp
@@ -459,11 +459,34 @@ CAMLprim value resdl_SDL_GetDesktopDisplayMode(value vDisplay) {
   CAMLreturn(ret);
 };
 
+CAMLprim value resdl_SDL_GetPixelFormatName(value vPixelFormat) {
+  CAMLparam1(vPixelFormat);
+  CAMLlocal1(ret);
+
+  Uint32 format = Int_val(vPixelFormat);
+  const char *szPixelFormatName = SDL_GetPixelFormatName(format);
+
+  if (!szPixelFormatName) {
+    ret = caml_copy_string("(null)");
+  } else {
+    ret = caml_copy_string(szPixelFormatName);
+  }
+
+  CAMLreturn(ret);
+}
+
 CAMLprim value resdl_SDL_GetWindowDisplayIndex(value w) {
   CAMLparam1(w);
   SDL_Window *win = (SDL_Window *)w;
   int idx = SDL_GetWindowDisplayIndex(win);
   CAMLreturn(Val_int(idx));
+};
+
+CAMLprim value resdl_SDL_GetWindowPixelFormat(value vWin) {
+  CAMLparam1(vWin);
+  SDL_Window *pWin = (SDL_Window *)vWin;
+  Uint32 format = SDL_GetWindowPixelFormat(pWin);
+  CAMLreturn(Val_int(format));
 };
 
 CAMLprim value resdl_SDL_GL_SetSwapInterval(value vInterval) {


### PR DESCRIPTION
This lets us query for the window's pixel format, hopefully helping to narrow down the error here: https://github.com/onivim/oni2/issues/1185