### PR TITLE
Fix segfault on callback

### DIFF
--- a/src/sdl2.re
+++ b/src/sdl2.re
@@ -175,7 +175,10 @@ module Window = {
     };
   };
 
+  let _resize = (_arg) => prerr_endline ("Resizing!");
+
   Callback.register("__sdl2_caml_hittest__", _hitTest);
+  Callback.register("__sdl2_caml_resize__", _resize);
 
   external hide: t => unit = "resdl_SDL_HideWindow";
   external raise: t => unit = "resdl_SDL_RaiseWindow";

--- a/src/sdl2.re
+++ b/src/sdl2.re
@@ -150,8 +150,6 @@ module Window = {
   external setTitle: (t, string) => unit = "resdl_SDL_SetWindowTitle";
   external setMinimumSize: (t, int, int) => unit =
     "resdl_SDL_SetWindowMinimumSize";
-  external setResizeCallback: (unit => bool) => unit =
-    "resdl_SDL_SetWindowResizeCallback";
 
   external _enableHitTest: t => unit = "resdl_SDL_EnableHitTest";
   external _disableHitTest: t => unit = "resdl_SDL_EnableHitTest";
@@ -175,10 +173,7 @@ module Window = {
     };
   };
 
-  let _resize = (_arg) => prerr_endline ("Resizing!");
-
   Callback.register("__sdl2_caml_hittest__", _hitTest);
-  Callback.register("__sdl2_caml_resize__", _resize);
 
   external hide: t => unit = "resdl_SDL_HideWindow";
   external raise: t => unit = "resdl_SDL_RaiseWindow";
@@ -670,7 +665,7 @@ let _nativeLoop = renderFn => {
 };
 
 let renderLoop = (renderFunction: renderFunction) => {
-  Window.setResizeCallback(renderFunction);
+  Callback.register("__sdl2_caml_resize__", renderFunction);
   switch (Sys.backend_type) {
   | Native => _nativeLoop(renderFunction)
   | Bytecode => _nativeLoop(renderFunction)

--- a/src/sdl2_wrapper.cpp
+++ b/src/sdl2_wrapper.cpp
@@ -1127,6 +1127,27 @@ CAMLprim value resdl_SDL_WindowCenter(value vWin) {
   CAMLreturn(Val_unit);
 }
 
+int resizeListener(void *data, SDL_Event *event) {
+  if (event->type == SDL_WINDOWEVENT &&
+      event->window.event == SDL_WINDOWEVENT_RESIZED) {
+    //value *f = (value *)data;
+    value args[] = {Val_unit};
+    caml_c_thread_register();
+
+    caml_acquire_runtime_system();
+
+    static const value *resizeCallback = NULL;
+    if (resizeCallback == NULL) {
+      resizeCallback = caml_named_value("__sdl2_caml_resize__");
+    }
+
+    if (resizeCallback) {
+      caml_callbackN(*resizeCallback, 1, args);
+    }
+    caml_release_runtime_system();
+  }
+  return 0;
+}
 
 CAMLprim value resdl_SDL_CreateWindow(value vWidth, value vHeight,
                                       value vName) {
@@ -1173,6 +1194,8 @@ CAMLprim value resdl_SDL_CreateWindow(value vWidth, value vHeight,
     SDL_LogCritical(SDL_LOG_CATEGORY_ERROR, "SDL_CreateWindow failed: %s\n",
                     SDL_GetError());
   }
+
+  SDL_AddEventWatch(resizeListener, NULL);
 
   value vWindow = (value)win;
   CAMLreturn(vWindow);
@@ -1248,34 +1271,6 @@ CAMLprim value resdl_SDL_ShowWindow(value vWin) {
 
   SDL_Window *win = (SDL_Window *)vWin;
   SDL_ShowWindow(win);
-
-  CAMLreturn(Val_unit);
-}
-
-int resizeListener(void *data, SDL_Event *event) {
-  if (event->type == SDL_WINDOWEVENT &&
-      event->window.event == SDL_WINDOWEVENT_RESIZED) {
-    //value *f = (value *)data;
-    value args[] = {Val_unit};
-    caml_c_thread_register();
-      
-    caml_acquire_runtime_system();
-  
-    static const value *resizeCallback = NULL;
-    if (resizeCallback == NULL) {
-      resizeCallback = caml_named_value("__sdl2_caml_resize__");
-    }
-
-    caml_callbackN(*resizeCallback, 1, args);
-    caml_release_runtime_system();
-  }
-  return 0;
-}
-
-CAMLprim value resdl_SDL_SetWindowResizeCallback(value vCallback) {
-  CAMLparam1(vCallback);
-
-  SDL_AddEventWatch(resizeListener, &vCallback);
 
   CAMLreturn(Val_unit);
 }

--- a/src/sdl2_wrapper.cpp
+++ b/src/sdl2_wrapper.cpp
@@ -1255,11 +1255,18 @@ CAMLprim value resdl_SDL_ShowWindow(value vWin) {
 int resizeListener(void *data, SDL_Event *event) {
   if (event->type == SDL_WINDOWEVENT &&
       event->window.event == SDL_WINDOWEVENT_RESIZED) {
-    value *f = (value *)data;
+    //value *f = (value *)data;
     value args[] = {Val_unit};
     caml_c_thread_register();
+      
     caml_acquire_runtime_system();
-    caml_callbackN(*f, 1, args);
+  
+    static const value *resizeCallback = NULL;
+    if (resizeCallback == NULL) {
+      resizeCallback = caml_named_value("__sdl2_caml_resize__");
+    }
+
+    caml_callbackN(*resizeCallback, 1, args);
     caml_release_runtime_system();
   }
   return 0;


### PR DESCRIPTION
FYI @zbaylin - just an idea I had for fixing a segfault with the resize handler. This is a similar strategy to how the `HitTest` APIs are implemented - using `Callback.register` to associate a name with a function on the Reason / OCaml side, and then using `caml_named_value` to get an up-to-date reference to the function on the C side.