### PR TITLE
add x and y arguments to Window.create

### DIFF
--- a/examples/basic.re
+++ b/examples/basic.re
@@ -26,7 +26,8 @@ let run = () => {
 
   Console.log("Operating system: " ++ Sdl2.Platform.getName());
   Console.log("Operating system version: " ++ Sdl2.Platform.getVersion());
-  let primaryWindow = Sdl2.Window.create(100, 100, "test");
+  let primaryWindow =
+    Sdl2.Window.create("test", `Centered, `Centered, 100, 100);
   let context = Sdl2.Gl.setup(primaryWindow);
   let version = Sdl2.Gl.getString(Sdl2.Gl.Version);
   let vendor = Sdl2.Gl.getString(Sdl2.Gl.Vendor);

--- a/src/sdl2.re
+++ b/src/sdl2.re
@@ -134,7 +134,16 @@ module Window = {
 
   type hitTestCallback = (t, int, int) => hitTestResult;
 
-  external create: (int, int, string) => t = "resdl_SDL_CreateWindow";
+  external create:
+    (
+      string,
+      [ | `Undefined | `Centered | `Absolute(int)],
+      [ | `Undefined | `Centered | `Absolute(int)],
+      int,
+      int
+    ) =>
+    t =
+    "resdl_SDL_CreateWindow";
   external getId: t => int = "resdl_SDL_GetWindowId";
   external getSize: t => Size.t = "resdl_SDL_GetWindowSize";
   external getPosition: t => (int, int) = "resdl_SDL_GetWindowPosition";

--- a/src/sdl2_wrapper.cpp
+++ b/src/sdl2_wrapper.cpp
@@ -1146,9 +1146,27 @@ CAMLprim value resdl_SDL_WindowCenter(value vWin) {
   CAMLreturn(Val_unit);
 }
 
-CAMLprim value resdl_SDL_CreateWindow(value vWidth, value vHeight,
-                                      value vName) {
-  CAMLparam3(vWidth, vHeight, vName);
+CAMLprim value resdl_SDL_CreateWindow(value vName, value vX, value vY,
+                                      value vWidth, value vHeight) {
+  CAMLparam5(vName, vX, vY, vWidth, vHeight);
+
+  int x;
+  if (vX == hash_variant("Centered")) {
+    x = SDL_WINDOWPOS_CENTERED;
+  } else if (Is_block(vX) && Field(vX, 0) == hash_variant("Absolute")) {
+    x = Int_val(Field(vX, 1));
+  } else {
+    x = SDL_WINDOWPOS_UNDEFINED;
+  };
+  
+  int y;
+  if (vY == hash_variant("Centered")) {
+    y = SDL_WINDOWPOS_CENTERED;
+  } else if (Is_block(vY) && Field(vY, 0) == hash_variant("Absolute")) {
+    y = Int_val(Field(vY, 1));
+  } else {
+    y = SDL_WINDOWPOS_UNDEFINED;
+  };
 
   int width = Int_val(vWidth);
   int height = Int_val(vHeight);
@@ -1183,8 +1201,7 @@ CAMLprim value resdl_SDL_CreateWindow(value vWidth, value vHeight,
   SDL_GL_SetAttribute(SDL_GL_ACCELERATED_VISUAL, 1);
 
   SDL_Window *win = (SDL_CreateWindow(
-      String_val(vName), SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, width,
-      height,
+      String_val(vName), x, y, width, height,
       SDL_WINDOW_OPENGL | SDL_WINDOW_ALLOW_HIGHDPI | SDL_WINDOW_RESIZABLE));
 
   if (!win) {


### PR DESCRIPTION
The `` `Centered`` value actually seems kind of useless as SDL will position the window before setting the size, so the window will end up with he top left corner in the center. We'll have to rectify that in Revery by calculating the center point ourselves I think.