### PR TITLE
Bind to all the SDL2 DropEvents

### DIFF
--- a/src/sdl2.re
+++ b/src/sdl2.re
@@ -684,12 +684,7 @@ module Event = {
         y,
       )
     | DropBegin({windowID, x, y, _}) =>
-      Printf.sprintf(
-        "DropBegin - windowID: %d x: %d y: %d\n",
-        windowID,
-        x,
-        y,
-      )
+      Printf.sprintf("DropBegin - windowID: %d x: %d y: %d\n", windowID, x, y)
     | DropComplete({windowID, x, y, _}) =>
       Printf.sprintf(
         "DropComplete - windowID: %d x: %d y: %d\n",

--- a/src/sdl2.re
+++ b/src/sdl2.re
@@ -205,7 +205,7 @@ module Window = {
   external minimize: t => unit = "resdl_SDL_MinimizeWindow";
   external restore: t => unit = "resdl_SDL_RestoreWindow";
   external maximize: t => unit = "resdl_SDL_MaximizeWindow";
-  
+
   external isMaximized: t => bool = "resdl_SDL_IsWindowMaximized";
 
   external getDisplay: t => Display.t = "resdl_SDL_GetWindowDisplayIndex";
@@ -501,6 +501,14 @@ module Event = {
     height: int,
   };
 
+  type dropEvent = {
+    windowID: int,
+    file: option(string),
+    timestamp: int,
+    x: int,
+    y: int,
+  };
+
   type t =
     | Quit
     | MouseMotion(mouseMotion) // 0
@@ -516,18 +524,22 @@ module Event = {
     | WindowExposed(windowEvent) // 10
     | WindowMoved(windowMoveEvent) // 11
     | WindowResized(windowSizeEvent) // 12
-    | WindowSizeChanged(windowSizeEvent) //12
-    | WindowMinimized(windowEvent)
-    | WindowMaximized(windowEvent)
-    | WindowRestored(windowEvent)
-    | WindowEnter(windowEvent)
-    | WindowLeave(windowEvent)
-    | WindowFocusGained(windowEvent)
-    | WindowFocusLost(windowEvent)
-    | WindowClosed(windowEvent)
-    | WindowTakeFocus(windowEvent)
-    | WindowHitTest(windowEvent)
-    | MousePan(mousePan)
+    | WindowSizeChanged(windowSizeEvent) // 13
+    | WindowMinimized(windowEvent) // 14
+    | WindowMaximized(windowEvent) // 15
+    | WindowRestored(windowEvent) // 16
+    | WindowEnter(windowEvent) // 17
+    | WindowLeave(windowEvent) // 18
+    | WindowFocusGained(windowEvent) // 19
+    | WindowFocusLost(windowEvent) // 20
+    | WindowClosed(windowEvent) // 21
+    | WindowTakeFocus(windowEvent) // 22
+    | WindowHitTest(windowEvent) // 23
+    | MousePan(mousePan) // 24
+    | DropText(dropEvent) // 25
+    | DropFile(dropEvent) // 26
+    | DropBegin(dropEvent) // 27
+    | DropComplete(dropEvent) // 28
     // An event that hasn't been implemented yet
     | Unknown
     | KeymapChanged;
@@ -649,6 +661,42 @@ module Event = {
       Printf.sprintf("WindowTakeFocus: %d\n", windowID)
     | WindowHitTest({windowID}) =>
       Printf.sprintf("WindowHitTest: %d\n", windowID)
+    | DropText({windowID, file, x, y, _}) =>
+      Printf.sprintf(
+        "DropText - windowID: %d file: %s x: %d y: %d\n",
+        windowID,
+        switch (file) {
+        | Some(f) => f
+        | None => ""
+        },
+        x,
+        y,
+      )
+    | DropFile({windowID, file, x, y, _}) =>
+      Printf.sprintf(
+        "DropFile - windowID: %d file: %s x: %d y: %d\n",
+        windowID,
+        switch (file) {
+        | Some(f) => f
+        | None => ""
+        },
+        x,
+        y,
+      )
+    | DropBegin({windowID, x, y, _}) =>
+      Printf.sprintf(
+        "DropBegin - windowID: %d x: %d y: %d\n",
+        windowID,
+        x,
+        y,
+      )
+    | DropComplete({windowID, x, y, _}) =>
+      Printf.sprintf(
+        "DropComplete - windowID: %d x: %d y: %d\n",
+        windowID,
+        x,
+        y,
+      )
     | KeymapChanged => "KeymapChanged"
     | Unknown => "Unknown"
     };

--- a/src/sdl2.re
+++ b/src/sdl2.re
@@ -1,6 +1,19 @@
 module Float32Array = Float32Array;
 module Uint16Array = Uint16Array;
 
+// Added this small unwrap function as a sort
+// of shim for 4.08's Option.value. This can be
+// removed if and when the package relies on >=4.08
+let unwrap = (~default: 'a=?, opt) =>
+  switch (opt) {
+  | Some(v) => v
+  | None =>
+    switch (default) {
+    | Some(v2) => v2
+    | None => raise(Not_found);
+    }
+  };
+
 module Size = {
   type t = {
     width: int,
@@ -665,10 +678,7 @@ module Event = {
       Printf.sprintf(
         "DropText - windowID: %d file: %s x: %d y: %d\n",
         windowID,
-        switch (file) {
-        | Some(f) => f
-        | None => ""
-        },
+        unwrap(~default="", file),
         x,
         y,
       )
@@ -676,10 +686,7 @@ module Event = {
       Printf.sprintf(
         "DropFile - windowID: %d file: %s x: %d y: %d\n",
         windowID,
-        switch (file) {
-        | Some(f) => f
-        | None => ""
-        },
+        unwrap(~default="", file),
         x,
         y,
       )

--- a/src/sdl2.re
+++ b/src/sdl2.re
@@ -10,7 +10,7 @@ let unwrap = (~default: 'a=?, opt) =>
   | None =>
     switch (default) {
     | Some(v2) => v2
-    | None => raise(Not_found);
+    | None => raise(Not_found)
     }
   };
 

--- a/src/sdl2_wrapper.cpp
+++ b/src/sdl2_wrapper.cpp
@@ -652,11 +652,20 @@ CAMLprim value Val_SDL_WindowEventWithData(int type, int windowID, int data1,
   CAMLreturn(ret);
 }
 
+void getNonFocusedMousePosition(SDL_Window *window, int *x, int *y) {
+  int mouseX, mouseY;
+  SDL_GetGlobalMouseState(&mouseX, &mouseY);
+  int windowX, windowY;
+  SDL_GetWindowPosition(window, &windowX, &windowY);
+  *x = mouseX - windowX;
+  *y = mouseY - windowY;
+}
+
 CAMLprim value Val_SDL_Event(SDL_Event *event) {
   CAMLparam0();
   CAMLlocal2(v, vInner);
 
-  int tag, mouseButton;
+  int tag, mouseButton, x, y;
 
   switch (event->type) {
   case SDL_QUIT:
@@ -770,6 +779,66 @@ CAMLprim value Val_SDL_Event(SDL_Event *event) {
     Store_field(vInner, 8, Val_int(event->pan.timestamp));
 
     Store_field(v, 0, vInner);
+    break;
+  case SDL_DROPTEXT:
+    v = caml_alloc(1, 25);
+    vInner = caml_alloc(5, 0);
+
+    getNonFocusedMousePosition(SDL_GetWindowFromID(event->drop.windowID), &x, &y);
+
+    Store_field(vInner, 0, Val_int(event->drop.windowID));
+    Store_field(vInner, 1, Val_some(caml_copy_string(event->drop.file)));
+    Store_field(vInner, 2, Val_int(event->drop.timestamp));
+    Store_field(vInner, 3, Val_int(x));
+    Store_field(vInner, 4, Val_int(y));
+
+    Store_field(v, 0, vInner);
+    SDL_free(event->drop.file);
+    break;
+  case SDL_DROPFILE:
+    v = caml_alloc(1, 26);
+    vInner = caml_alloc(5, 0);
+
+    getNonFocusedMousePosition(SDL_GetWindowFromID(event->drop.windowID), &x, &y);
+
+    Store_field(vInner, 0, Val_int(event->drop.windowID));
+    Store_field(vInner, 1, Val_some(caml_copy_string(event->drop.file)));
+    Store_field(vInner, 2, Val_int(event->drop.timestamp));
+    Store_field(vInner, 3, Val_int(x));
+    Store_field(vInner, 4, Val_int(y));
+
+    Store_field(v, 0, vInner);
+    SDL_free(event->drop.file);
+    break;
+  case SDL_DROPBEGIN:
+    v = caml_alloc(1, 27);
+    vInner = caml_alloc(5, 0);
+
+    getNonFocusedMousePosition(SDL_GetWindowFromID(event->drop.windowID), &x, &y);
+
+    Store_field(vInner, 0, Val_int(event->drop.windowID));
+    Store_field(vInner, 1, Val_none);
+    Store_field(vInner, 2, Val_int(event->drop.timestamp));
+    Store_field(vInner, 3, Val_int(x));
+    Store_field(vInner, 4, Val_int(y));
+
+    Store_field(v, 0, vInner);
+    SDL_free(event->drop.file);
+    break;
+  case SDL_DROPCOMPLETE:
+    v = caml_alloc(1, 28);
+    vInner = caml_alloc(5, 0);
+
+    getNonFocusedMousePosition(SDL_GetWindowFromID(event->drop.windowID), &x, &y);
+
+    Store_field(vInner, 0, Val_int(event->drop.windowID));
+    Store_field(vInner, 1, Val_none);
+    Store_field(vInner, 2, Val_int(event->drop.timestamp));
+    Store_field(vInner, 3, Val_int(x));
+    Store_field(vInner, 4, Val_int(y));
+
+    Store_field(v, 0, vInner);
+    SDL_free(event->drop.file);
     break;
   case SDL_KEYMAPCHANGED:
     v = Val_int(2);
@@ -930,16 +999,16 @@ CAMLprim value resdl_SDL_GetWindowSize(value vWindow) {
 CAMLprim value resdl_SDL_GetWindowPosition(value vWindow) {
   CAMLparam1(vWindow);
   CAMLlocal1(position);
-  
+
   SDL_Window *win = (SDL_Window *)vWindow;
   int x, y = 0;
 
   SDL_GetWindowPosition(win, &x, &y);
-  
+
   position = caml_alloc(2, 0);
   Store_field(position, 0, Val_int(x));
   Store_field(position, 1, Val_int(y));
-  
+
   CAMLreturn(position);
 }
 
@@ -1198,7 +1267,7 @@ CAMLprim value resdl_SDL_CreateWindow(value vName, value vX, value vY,
   } else {
     x = SDL_WINDOWPOS_UNDEFINED;
   };
-  
+
   int y;
   if (vY == hash_variant("Centered")) {
     y = SDL_WINDOWPOS_CENTERED;

--- a/src/sdl2_wrapper.cpp
+++ b/src/sdl2_wrapper.cpp
@@ -652,20 +652,20 @@ CAMLprim value Val_SDL_WindowEventWithData(int type, int windowID, int data1,
   CAMLreturn(ret);
 }
 
-void getNonFocusedMousePosition(SDL_Window *window, int *x, int *y) {
-  int mouseX, mouseY;
-  SDL_GetGlobalMouseState(&mouseX, &mouseY);
+void getNonFocusedMousePosition(SDL_Window *window, int *localMouseX, int *localMouseY) {
+  int globalMouseX, globalMouseY;
+  SDL_GetGlobalMouseState(&globalMouseX, &globalMouseY);
   int windowX, windowY;
   SDL_GetWindowPosition(window, &windowX, &windowY);
-  *x = mouseX - windowX;
-  *y = mouseY - windowY;
+  *localMouseX = globalMouseX - windowX;
+  *localMouseY = globalMouseY - windowY;
 }
 
 CAMLprim value Val_SDL_Event(SDL_Event *event) {
   CAMLparam0();
   CAMLlocal2(v, vInner);
 
-  int tag, mouseButton, x, y;
+  int tag, mouseButton, mousePosX, mousePosY;
 
   switch (event->type) {
   case SDL_QUIT:
@@ -784,13 +784,13 @@ CAMLprim value Val_SDL_Event(SDL_Event *event) {
     v = caml_alloc(1, 25);
     vInner = caml_alloc(5, 0);
 
-    getNonFocusedMousePosition(SDL_GetWindowFromID(event->drop.windowID), &x, &y);
+    getNonFocusedMousePosition(SDL_GetWindowFromID(event->drop.windowID), &mousePosX, &mousePosY);
 
     Store_field(vInner, 0, Val_int(event->drop.windowID));
     Store_field(vInner, 1, Val_some(caml_copy_string(event->drop.file)));
     Store_field(vInner, 2, Val_int(event->drop.timestamp));
-    Store_field(vInner, 3, Val_int(x));
-    Store_field(vInner, 4, Val_int(y));
+    Store_field(vInner, 3, Val_int(mousePosX));
+    Store_field(vInner, 4, Val_int(mousePosY));
 
     Store_field(v, 0, vInner);
     SDL_free(event->drop.file);
@@ -799,13 +799,13 @@ CAMLprim value Val_SDL_Event(SDL_Event *event) {
     v = caml_alloc(1, 26);
     vInner = caml_alloc(5, 0);
 
-    getNonFocusedMousePosition(SDL_GetWindowFromID(event->drop.windowID), &x, &y);
+    getNonFocusedMousePosition(SDL_GetWindowFromID(event->drop.windowID), &mousePosX, &mousePosY);
 
     Store_field(vInner, 0, Val_int(event->drop.windowID));
     Store_field(vInner, 1, Val_some(caml_copy_string(event->drop.file)));
     Store_field(vInner, 2, Val_int(event->drop.timestamp));
-    Store_field(vInner, 3, Val_int(x));
-    Store_field(vInner, 4, Val_int(y));
+    Store_field(vInner, 3, Val_int(mousePosX));
+    Store_field(vInner, 4, Val_int(mousePosY));
 
     Store_field(v, 0, vInner);
     SDL_free(event->drop.file);
@@ -814,13 +814,13 @@ CAMLprim value Val_SDL_Event(SDL_Event *event) {
     v = caml_alloc(1, 27);
     vInner = caml_alloc(5, 0);
 
-    getNonFocusedMousePosition(SDL_GetWindowFromID(event->drop.windowID), &x, &y);
+    getNonFocusedMousePosition(SDL_GetWindowFromID(event->drop.windowID), &mousePosX, &mousePosY);
 
     Store_field(vInner, 0, Val_int(event->drop.windowID));
     Store_field(vInner, 1, Val_none);
     Store_field(vInner, 2, Val_int(event->drop.timestamp));
-    Store_field(vInner, 3, Val_int(x));
-    Store_field(vInner, 4, Val_int(y));
+    Store_field(vInner, 3, Val_int(mousePosX));
+    Store_field(vInner, 4, Val_int(mousePosY));
 
     Store_field(v, 0, vInner);
     SDL_free(event->drop.file);
@@ -829,13 +829,13 @@ CAMLprim value Val_SDL_Event(SDL_Event *event) {
     v = caml_alloc(1, 28);
     vInner = caml_alloc(5, 0);
 
-    getNonFocusedMousePosition(SDL_GetWindowFromID(event->drop.windowID), &x, &y);
+    getNonFocusedMousePosition(SDL_GetWindowFromID(event->drop.windowID), &mousePosX, &mousePosY);
 
     Store_field(vInner, 0, Val_int(event->drop.windowID));
     Store_field(vInner, 1, Val_none);
     Store_field(vInner, 2, Val_int(event->drop.timestamp));
-    Store_field(vInner, 3, Val_int(x));
-    Store_field(vInner, 4, Val_int(y));
+    Store_field(vInner, 3, Val_int(mousePosX));
+    Store_field(vInner, 4, Val_int(mousePosY));
 
     Store_field(v, 0, vInner);
     SDL_free(event->drop.file);


### PR DESCRIPTION
This binds to all the SDL2 drop events:
- `SDL_DROPFILE`
- `SDL_DROPTEXT`
- `SDL_DROPBEGIN`
- `SDL_DROPCOMPLETE`
It also adds a convenience function in the C++ stubs to get mouse coordinates while the window isn't in focus, which is common when dragging & dropping files.

See https://wiki.libsdl.org/SDL_DropEvent for more info