### PR TITLE
return result from Window.create instead of failing unrecoverably

### DIFF
--- a/examples/basic.re
+++ b/examples/basic.re
@@ -27,7 +27,8 @@ let run = () => {
   Console.log("Operating system: " ++ Sdl2.Platform.getName());
   Console.log("Operating system version: " ++ Sdl2.Platform.getVersion());
   let primaryWindow =
-    Sdl2.Window.create("test", `Centered, `Centered, 100, 100);
+    Sdl2.Window.create("test", `Centered, `Centered, 100, 100)
+    |> Result.get_ok;
   let context = Sdl2.Gl.setup(primaryWindow);
   let version = Sdl2.Gl.getString(Sdl2.Gl.Version);
   let vendor = Sdl2.Gl.getString(Sdl2.Gl.Vendor);

--- a/src/sdl2.re
+++ b/src/sdl2.re
@@ -155,7 +155,7 @@ module Window = {
       int,
       int
     ) =>
-    t =
+    result(t, string) =
     "resdl_SDL_CreateWindow";
   external getId: t => int = "resdl_SDL_GetWindowId";
   external getSize: t => Size.t = "resdl_SDL_GetWindowSize";

--- a/src/sdl2_wrapper.cpp
+++ b/src/sdl2_wrapper.cpp
@@ -1334,14 +1334,12 @@ CAMLprim value resdl_SDL_CreateWindow(value vName, value vX, value vY,
       SDL_WINDOW_OPENGL | SDL_WINDOW_ALLOW_HIGHDPI | SDL_WINDOW_RESIZABLE));
 
   if (!win) {
-    SDL_LogCritical(SDL_LOG_CATEGORY_ERROR, "SDL_CreateWindow failed: %s\n",
-                    SDL_GetError());
+    value error = caml_copy_string(SDL_GetError());
+    CAMLreturn(Val_error(error));
+  } else {
+    SDL_AddEventWatch(resizeListener, NULL);
+    CAMLreturn(Val_ok((value)win));
   }
-
-  SDL_AddEventWatch(resizeListener, NULL);
-
-  value vWindow = (value)win;
-  CAMLreturn(vWindow);
 }
 
 CAMLprim value resdl_SDL_SetWindowBordered(value vWin, value vBordered) {


### PR DESCRIPTION
This is a breaking change, obviously.