### PR TITLE
Added function to determine if a window is fullscreen or not

### DIFF
--- a/src/sdl2.re
+++ b/src/sdl2.re
@@ -207,6 +207,7 @@ module Window = {
   external maximize: t => unit = "resdl_SDL_MaximizeWindow";
 
   external isMaximized: t => bool = "resdl_SDL_IsWindowMaximized";
+  external isFullscreen: t => bool = "resdl_SDL_IsWindowFullscreen";
 
   external getDisplay: t => Display.t = "resdl_SDL_GetWindowDisplayIndex";
 

--- a/src/sdl2_wrapper.cpp
+++ b/src/sdl2_wrapper.cpp
@@ -1392,6 +1392,25 @@ CAMLprim value resdl_SDL_IsWindowMaximized(value vWin) {
   CAMLreturn(Val_bool(hasMaximizedFlag));
 }
 
+CAMLprim value resdl_SDL_IsWindowFullscreen(value vWin) {
+  CAMLparam1(vWin);
+  // SDL's fullscreen window flags don't work on macOS
+  SDL_Window *win = (SDL_Window *)vWin;
+  bool isFullscreen;
+#ifdef __APPLE__
+  SDL_SysWMinfo wmInfo;
+  SDL_VERSION(&wmInfo.version);
+  SDL_GetWindowWMInfo(win, &wmInfo);
+  NSWindow *nWindow = wmInfo.info.cocoa.window;
+  isFullscreen = (([nWindow styleMask] & NSWindowStyleMaskFullScreen) == NSWindowStyleMaskFullScreen);
+#else
+  Uint32 flags = SDL_GetWindowFlags(win);
+  isFullscreen = (flags & SDL_WINDOW_FULLSCREEN) != 0;
+#endif
+
+  CAMLreturn(Val_bool(isFullscreen));
+}
+
 CAMLprim value resdl_SDL_MinimizeWindow(value vWin) {
   CAMLparam1(vWin);
 


### PR DESCRIPTION
I had to make a custom implementation for macOS, because for some reason SDL2 has issues with fullscreening in general on macOS.

I didn't add a `setFullscreen` function either, because it appears to be unstable across platforms.

This is mainly to address onivim/oni2#1462. This will allow us to differentiate between the window being fullscreen (i.e. taking up an entire desktop non-windowed) and maximized (i.e. taking up an entire desktop windowed).